### PR TITLE
Migrating container images to Google Artifact Registry

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -5,7 +5,6 @@
 Para que os componentes dos participantes do Drex possam utilizar a Rayls, é necessário:
 
 - Acesso ao repositório piloto_rd_setup.
-- Acesso ao registry da Parfin (registry.parfin.io)
 - WSL/Sistema operacional Linux
 - ChainID que foi disponibilizado previamente pelo Banco Central
 - [Make](https://www.gnu.org/software/make/)
@@ -63,12 +62,7 @@ db.secrets.find()
 
 ### Instalação
 
-1. Realizar login no registry da Parfin:
-```bash
-docker login registry.parfin.io
-```
-
-2. Para inicializar o ambiente Rayls com MongoDB local basta utilizar o seguinte comando:
+1. Para inicializar o ambiente Rayls com MongoDB local basta utilizar o seguinte comando:
 
 #### Inicializando a Rayls utilizando MongoDB local
 ```bash

--- a/docker/examples/docker-compose.yml.example
+++ b/docker/examples/docker-compose.yml.example
@@ -1,6 +1,6 @@
 services:
   privacy-ledger:
-    image: registry.parfin.io/rayls-privacy-ledger:v1.8.6
+    image: us-east1-docker.pkg.dev/rayls-public/rayls/rayls-privacy-ledger:v1.8.6
     entrypoint: ["/app/var/start.sh"]
     volumes:
       - ./rayls/privacy-ledger/data:/app/data
@@ -14,7 +14,7 @@ services:
       - 8545:8545
       - 8660:8660
   relayer:
-      image: registry.parfin.io/rayls-relayer:v1.8.6.1
+      image: us-east1-docker.pkg.dev/rayls-public/rayls/rayls-relayer:v1.8.6.1
       entrypoint: ["/app/raylz-relayer", "run", "--config", "/app/var/empty-config.json"]
       volumes:
        - ./rayls/relayer/var/config.json:/app/var/empty-config.json:ro

--- a/docker/examples/docker-compose.yml.mongodb
+++ b/docker/examples/docker-compose.yml.mongodb
@@ -1,12 +1,12 @@
 services:
   mongodb:
-    image: registry.parfin.io/mongo6_rs:latest
+    image: us-east1-docker.pkg.dev/rayls-public/rayls/rayls-mongors:latest
     ports:
       - "27017:27017"
     volumes:
       - ./mongodb/data:/data/db
   privacy-ledger:
-    image: registry.parfin.io/rayls-privacy-ledger:v1.8.6
+    image: us-east1-docker.pkg.dev/rayls-public/rayls/rayls-privacy-ledger:v1.8.6
     entrypoint: ["/app/var/start.sh"]
     volumes:
       - ./rayls/privacy-ledger/data:/app/data
@@ -20,7 +20,7 @@ services:
       - 8545:8545
       - 8660:8660
   relayer:
-      image: registry.parfin.io/rayls-relayer:v1.8.6.1
+      image: us-east1-docker.pkg.dev/rayls-public/rayls/rayls-relayer:v1.8.6.1
       entrypoint: ["/app/raylz-relayer", "run", "--config", "/app/var/empty-config.json"]
       volumes:
        - ./rayls/relayer/var/config.json:/app/var/empty-config.json:ro

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -20,18 +20,6 @@
 kubectl create namespace <namespace>
 ```
 
-### Adicionando as credenciais no cluster Kubernetes (opcional)
-
-- Crie a secret que concederá acesso ao registry.parfin.io. Caso seu cluster tenha acesso ao registry ou esteja utilizando um repositório interno, esse passo é opcional. 
-
-> **⚠️ Atenção:**
->
-> Para solicitar essas credenciais, por favor entrar em contato através do e-mail drex-support@parfin.io.
-
-```bash
-kubectl create secret docker-registry registry-parfin-io --docker-server=registry.parfin.io --docker-username=xxxxx --docker-password=xxxxx --namespace=xxxxx
-```
-
 ### Clonar Repositorio
 
 - Faça clone do repositório piloto_rd_setup.
@@ -125,7 +113,7 @@ spec:
             claimName: rayls-privacy-ledger-pvc
       containers:
         - name: rayls-privacy-ledger
-          image: registry.parfin.io/rayls-privacy-ledger:v1.8.6
+          image: us-east1-docker.pkg.dev/rayls-public/rayls/rayls-privacy-ledger:v1.8.6
           imagePullPolicy: Always
           command: ["/app/var/start.sh"]
           resources:
@@ -163,8 +151,6 @@ spec:
               readOnly: true
             - mountPath: /app/data
               name: persistent-storage
-      imagePullSecrets:
-        - name: registry-parfin-io
 ```
 
 2. Alterar a capacidade de disco da Privacy Ledger nos manifestos PersistentVolume.yml e PersistentVolumeClaim

--- a/kubernetes/dependencies/mongodb.yml
+++ b/kubernetes/dependencies/mongodb.yml
@@ -44,14 +44,12 @@ spec:
             claimName: mongodb-pvc
       containers:
         - name: mongodb
-          image: registry.parfin.io/mongo6_rs:latest
+          image: us-east1-docker.pkg.dev/rayls-public/rayls/rayls-mongors:latest
           volumeMounts:
             - name: mongodb-data
               mountPath: /data/db
           ports:
             - containerPort: 27017
-      imagePullSecrets:
-        - name: registry-parfin-io
 ---
 apiVersion: v1
 kind: Service

--- a/kubernetes/rayls/privacy-ledger/StatefulSet.yml
+++ b/kubernetes/rayls/privacy-ledger/StatefulSet.yml
@@ -25,7 +25,7 @@ spec:
             claimName: rayls-privacy-ledger-pvc
       containers:
         - name: rayls-privacy-ledger
-          image: registry.parfin.io/rayls-privacy-ledger:v1.8.6
+          image: us-east1-docker.pkg.dev/rayls-public/rayls/rayls-privacy-ledger:v1.8.6
           imagePullPolicy: Always
           command: ["/app/var/start.sh"]
           resources:
@@ -63,5 +63,3 @@ spec:
               readOnly: true
             - mountPath: /app/data
               name: persistent-storage
-      imagePullSecrets:
-        - name: registry-parfin-io

--- a/kubernetes/rayls/relayer/Deployment.yml
+++ b/kubernetes/rayls/relayer/Deployment.yml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: rayls-relayer
-          image: registry.parfin.io/rayls-relayer:v1.8.6.1
+          image: us-east1-docker.pkg.dev/rayls-public/rayls/rayls-relayer:v1.8.6.1
           command: ["/app/raylz-relayer", "run", "--config", "/app/var/config.json"]
           resources:
             limits:
@@ -28,5 +28,3 @@ spec:
            configMap:
              defaultMode: 0700
              name: rayls-relayer
-      imagePullSecrets:
-        - name: registry-parfin-io


### PR DESCRIPTION
- Updated Docker and Kubernetes configurations to use images from `us-east1-docker.pkg.dev/rayls-public/rayls` instead of `registry.parfin.io`.
- Removed authentication requirements for the Parfin registry.
- Eliminated `imagePullSecrets` from Kubernetes manifests.
- Updated `docker-compose` examples to reflect the new registry.
- Revised documentation to remove instructions related to the Parfin registry.